### PR TITLE
[refactor] removing etherscan call

### DIFF
--- a/drivers/ethereum/fetch.go
+++ b/drivers/ethereum/fetch.go
@@ -27,7 +27,7 @@ func (d *Driver) queueGetContractMetadata(res interface{}) pool.Runner {
 }
 func (d *Driver) Fetchers() map[string]pool.FeedTransformer {
 	return map[string]pool.FeedTransformer{
-		stageFetchABI:      d.queueGetContractABI,
+		//stageFetchABI:      d.queueGetContractABI,
 		stageFetchMetadata: d.queueGetContractMetadata,
 	}
 }


### PR DESCRIPTION
This PR removes etherscan call in fetch.go For the time being, we are leaving the fetcher as a map of transformers since there might be a future solution to fetch ABI from a node :0 